### PR TITLE
Transform weight field to dropdown select and fix related displays

### DIFF
--- a/admin/partials/judoka-form.php
+++ b/admin/partials/judoka-form.php
@@ -1,11 +1,11 @@
 <?php
 
-if (!defined('ABSPATH'))
-{
+if (!defined('ABSPATH')) {
     exit;
 }
 
-function judoka_full_name_submit() {
+function judoka_full_name_submit()
+{
     if (isset($_POST['first_name']) && isset($_POST['last_name'])) {
         $first_name = trim(strtoupper($_POST['first_name']));
         $last_name = trim(strtoupper($_POST['last_name']));
@@ -14,7 +14,8 @@ function judoka_full_name_submit() {
 }
 add_action('init', 'judoka_full_name_submit');
 
-function render_judoka_form($judoka = null, $competitions = []) {
+function render_judoka_form($judoka = null, $competitions = [])
+{
     $is_edit = !is_null($judoka);
     $form_id = $is_edit ? 'form-edit-judoka' : 'form-judoka';
     $nonce_action = $is_edit  ? 'edit_judoka' : 'add_judoka_nonce';
@@ -27,18 +28,18 @@ function render_judoka_form($judoka = null, $competitions = []) {
         $first_name = isset($name_parts[0]) ? $name_parts[0] : '';
         $last_name = implode(' ', array_slice($name_parts, 1));
     }
-    ?>
+?>
 
     <div class="wrap">
         <h1><?php echo $is_edit ? 'Edit judoka' : 'Add new judoka'; ?></h1>
 
-        <form method="post" action="" enctype="multipart/form-data" id="<?php echo $form_id;?>" class="judoka-form">
+        <form method="post" action="" enctype="multipart/form-data" id="<?php echo $form_id; ?>" class="judoka-form">
             <?php wp_nonce_field($nonce_action, $nonce_name); ?>
 
-            <?php if($is_edit) : ?>
-                <input type="hidden" name="judoka_id" value="<?php echo $judoka->id;?>">
+            <?php if ($is_edit) : ?>
+                <input type="hidden" name="judoka_id" value="<?php echo $judoka->id; ?>">
                 <input type="hidden" name="old_photo_profile" value="<?php echo esc_attr($judoka->photo_profile); ?>">
-                <input type="hidden" name="old_images" value="<?php echo esc_attr(implode(',', (array)$judoka->images));?>">
+                <input type="hidden" name="old_images" value="<?php echo esc_attr(implode(',', (array)$judoka->images)); ?>">
             <?php endif; ?>
 
             <table class="form-table">
@@ -46,27 +47,27 @@ function render_judoka_form($judoka = null, $competitions = []) {
                     <th><label for="first_name">First Name</label></th>
                     <td>
                         <input type="text" id="first_name" name="first_name" class="regular-text" required
-                               value="<?php echo esc_attr($first_name); ?>">
+                            value="<?php echo esc_attr($first_name); ?>">
                     </td>
                 </tr>
                 <tr>
                     <th><label for="last_name">Last Name</label></th>
                     <td>
                         <input type="text" id="last_name" name="last_name" class="regular-text" required
-                               value="<?php echo esc_attr($last_name); ?>">
+                            value="<?php echo esc_attr($last_name); ?>">
                     </td>
                 </tr>
                 <tr style="display: none;">
                     <td colspan="2">
                         <input type="hidden" id="full_name" name="full_name"
-                               value="<?php echo $is_edit ? esc_attr($judoka->full_name) : ''; ?>">
+                            value="<?php echo $is_edit ? esc_attr($judoka->full_name) : ''; ?>">
                     </td>
                 </tr>
                 <tr>
                     <th><label for="birth_date">Birthdate</label></th>
                     <td>
                         <input type="date" id="birth_date" name="birth_date" required
-                               value="<?php echo $is_edit ? esc_attr($judoka->birth_date) : ''; ?>">
+                            value="<?php echo $is_edit ? esc_attr($judoka->birth_date) : ''; ?>">
                     </td>
                 </tr>
                 <tr>
@@ -82,15 +83,34 @@ function render_judoka_form($judoka = null, $competitions = []) {
                 <tr>
                     <th><label for="weight">Weight</label></th>
                     <td>
-                        <input type="number" step="0.1" id="weight" name="weight" class="regular-text" required
-                               value="<?php echo $is_edit ? esc_attr($judoka->weight) : ''; ?>">
+                        <select id="weight" name="weight" required>
+                            <option value="">Select a weight</option>
+                            <optgroup label="Male">
+                                <?php
+                                $weights_male = ['-60', '-66', '-73', '-81', '-90', '-100', '+100'];
+                                foreach ($weights_male as $weight) {
+                                    $selected = $is_edit && $judoka->weight === $weight ? 'selected' : '';
+                                    echo "<option value=\"{$weight}\" {$selected}>{$weight} kg</option>";
+                                }
+                                ?>
+                            </optgroup>
+                            <optgroup label="Female">
+                                <?php
+                                $weights_female = ['-48', '-52', '-57', '-63', '-70', '-78', '+78'];
+                                foreach ($weights_female as $weight) {
+                                    $selected = $is_edit && $judoka->weight === $weight ? 'selected' : '';
+                                    echo "<option value=\"{$weight}\" {$selected}>{$weight} kg</option>";
+                                }
+                                ?>
+                            </optgroup>
+                        </select>
                     </td>
                 </tr>
                 <tr>
                     <th><label for="club">Club</label></th>
                     <td>
                         <input type="text" id="club" name="club" class="regular-text" required
-                               value="<?php echo $is_edit ? esc_attr($judoka->club) : ''; ?>">
+                            value="<?php echo $is_edit ? esc_attr($judoka->club) : ''; ?>">
                     </td>
                 </tr>
                 <tr>
@@ -100,9 +120,17 @@ function render_judoka_form($judoka = null, $competitions = []) {
                             <option value="">Select a grade</option>
                             <?php
                             $grades = [
-                                'White belt', 'Yellow belt', 'Orange belt', 'Green belt',
-                                'Blue belt', 'Brown belt', 'Black belt 1st dan', 'Black belt 2nd dan',
-                                'Black belt 3rd dan', 'Black belt 4th dan', 'Black belt 5th dan'
+                                'White belt',
+                                'Yellow belt',
+                                'Orange belt',
+                                'Green belt',
+                                'Blue belt',
+                                'Brown belt',
+                                'Black belt 1st dan',
+                                'Black belt 2nd dan',
+                                'Black belt 3rd dan',
+                                'Black belt 4th dan',
+                                'Black belt 5th dan'
                             ];
                             foreach ($grades as $grade) {
                                 $selected = $is_edit && $judoka->grade === $grade ? 'selected' : '';
@@ -166,7 +194,7 @@ function render_judoka_form($judoka = null, $competitions = []) {
                                 <th colspan="2">
                                     <h4>Competition <?php echo $index + 1; ?></h4>
                                     <input type="hidden" name="competitions[<?php echo $index; ?>][id]"
-                                           value="<?php echo $competition->id; ?>">
+                                        value="<?php echo $competition->id; ?>">
                                     <button type="button" class="button remove-competition">Delete this competition</button>
                                 </th>
                             </tr>
@@ -174,28 +202,28 @@ function render_judoka_form($judoka = null, $competitions = []) {
                                 <th><label>Competition Name</label></th>
                                 <td>
                                     <input type="text" name="competitions[<?php echo $index; ?>][competition_name]"
-                                           class="regular-text" value="<?php echo esc_attr($competition->competition_name); ?>">
+                                        class="regular-text" value="<?php echo esc_attr($competition->competition_name); ?>">
                                 </td>
                             </tr>
                             <tr>
                                 <th><label>Competition Date</label></th>
                                 <td>
                                     <input type="date" name="competitions[<?php echo $index; ?>][date_competition]"
-                                           value="<?php echo esc_attr($competition->date_competition); ?>">
+                                        value="<?php echo esc_attr($competition->date_competition); ?>">
                                 </td>
                             </tr>
                             <tr>
                                 <th><label>Points Earned</label></th>
                                 <td>
                                     <input type="number" name="competitions[<?php echo $index; ?>][points]" min="0"
-                                           value="<?php echo esc_attr($competition->points); ?>">
+                                        value="<?php echo esc_attr($competition->points); ?>">
                                 </td>
                             </tr>
                             <tr>
                                 <th><label>Rank</label></th>
                                 <td>
                                     <input type="number" name="competitions[<?php echo $index; ?>][rang]" min="1"
-                                           value="<?php echo esc_attr($competition->rang); ?>">
+                                        value="<?php echo esc_attr($competition->rang); ?>">
                                 </td>
                             </tr>
                             <tr>
@@ -210,7 +238,7 @@ function render_judoka_form($judoka = null, $competitions = []) {
                                 </td>
                             </tr>
                         </table>
-                    <?php endforeach;
+                <?php endforeach;
                 endif; ?>
             </div>
             <button type="button" id="add-competition" class="button">Add another competition</button>
@@ -218,5 +246,5 @@ function render_judoka_form($judoka = null, $competitions = []) {
             <?php submit_button($is_edit ? 'Update changes' : 'Save changes')  ?>
         </form>
     </div>
-    <?php
+<?php
 }

--- a/includes/shortcodes/class-Judoka-performance-shortcode.php
+++ b/includes/shortcodes/class-Judoka-performance-shortcode.php
@@ -69,7 +69,7 @@ class Judoka_Performance_Shortcode
         $current_page_url = get_permalink();
 
         ob_start();
-        ?>
+?>
         <div class="judoka-list-container">
             <h2>Judoka List</h2>
 
@@ -113,7 +113,7 @@ class Judoka_Performance_Shortcode
                         $total_points = $this->competition_model->get_total_points($judoka->id) ?: 0;
 
                         $profile_url = add_query_arg('judoka_id', $judoka->id, $current_page_url);
-                        ?>
+                ?>
                         <a href="<?php echo esc_url($profile_url); ?>" class="judoka-card-link">
                             <div class="judoka-card"
                                 data-id="<?php echo esc_attr($judoka->id); ?>"
@@ -137,20 +137,20 @@ class Judoka_Performance_Shortcode
                                 </div>
                             </div>
                         </a>
-                        <?php
+                <?php
                     }
                 }
                 ?>
             </div>
         </div>
-        <?php
+    <?php
         return ob_get_clean();
     }
 
     public function render_judoka_details($judoka_id)
     {
         $judoka = $this->judoka_model->get_judoka($judoka_id);
-        
+
         if (!$judoka) {
             return '<p>Judoka not found.</p>';
         }
@@ -176,9 +176,9 @@ class Judoka_Performance_Shortcode
         $age = $birthdate->diff($today)->y;
 
         $photo_url = !empty($judoka->photo_profile) ? $judoka->photo_profile : $this->default_picture;
-        
+
         ob_start();
-        ?>
+    ?>
         <div class="judoka-profile-header" style="background-color: #3a3f78; background-image: linear-gradient(to right, #3a3f78, #2d305e);">
             <div class="profile-info">
                 <div class="profile-photo">
@@ -190,14 +190,14 @@ class Judoka_Performance_Shortcode
                         <img src="<?php echo esc_url($this->default_flag); ?>" alt="Drapeau" class="flag-icon">
                         <span><?php echo esc_html($judoka->club); ?></span>
                     </div>
-                    <p class="age-info">Age: <?php echo esc_html($age); ?> ans</p>
+                    <p class="age-info">Age: <?php echo esc_html((string)$age); ?> ans</p>
                 </div>
                 <div class="weight-display">
-                    -<?php echo esc_html($judoka->weight); ?>
+                    <?php echo esc_html($judoka->weight); ?>
                     <span class="weight-unit">kg</span>
                 </div>
             </div>
-            
+
             <div class="profile-tabs">
                 <a href="#overview" class="tab active">Overview</a>
                 <a href="#photos" class="tab">Photos</a>
@@ -207,13 +207,13 @@ class Judoka_Performance_Shortcode
                 <a href="#wrl" class="tab">WRL</a>
             </div>
         </div>
-        
+
         <div class="profile-content">
             <div id="overview" class="tab-content active">
                 <div class="section-title">
                     <h2>Under the spotlight</h2>
                 </div>
-                
+
                 <div class="spotlight-gallery">
                     <?php
                     $images = !empty($judoka->images) ? json_decode($judoka->images, true) : [];
@@ -222,41 +222,41 @@ class Judoka_Performance_Shortcode
                             echo '<div class="gallery-item"><img src="' . esc_url($image) . '" alt="Photo de ' . esc_attr($judoka->full_name) . '"></div>';
                         }
                     } else {
-                    
+
                         echo '<div class="gallery-item"><img src="' . esc_url($photo_url) . '" alt="Photo de ' . esc_attr($judoka->full_name) . '"></div>';
                     }
                     ?>
                 </div>
-                
+
                 <div class="performance-stats">
                     <div class="stat-container">
                         <div class="stat-box">
                             <div class="stat-value"><?php echo count($competitions); ?></div>
                             <div class="stat-label">Competitions</div>
                         </div>
-                        
+
                         <div class="stat-box">
                             <div class="stat-value"><?php echo $medalStats['Gold']; ?></div>
                             <div class="stat-label">Gold</div>
                         </div>
-                        
+
                         <div class="stat-box">
                             <div class="stat-value"><?php echo $medalStats['Silver']; ?></div>
                             <div class="stat-label">Silver</div>
                         </div>
-                        
+
                         <div class="stat-box">
                             <div class="stat-value"><?php echo $medalStats['Bronze']; ?></div>
                             <div class="stat-label">Bronze</div>
                         </div>
-                        
+
                         <div class="stat-box">
                             <div class="stat-value"><?php echo number_format((float)$totalPoints); ?></div>
                             <div class="stat-label">Points</div>
                         </div>
                     </div>
                 </div>
-                
+
                 <div class="recent-competitions">
                     <h3>Recent Competitions</h3>
                     <table class="competitions-table">
@@ -276,7 +276,7 @@ class Judoka_Performance_Shortcode
                             } else {
                                 foreach (array_slice($competitions, 0, 5) as $comp) {
                                     $medal_class = strtolower($comp->medals);
-                                    ?>
+                            ?>
                                     <tr>
                                         <td><?php echo esc_html(date('d/m/Y', strtotime($comp->date_competition))); ?></td>
                                         <td><?php echo esc_html($comp->competition_name); ?></td>
@@ -284,7 +284,7 @@ class Judoka_Performance_Shortcode
                                         <td><span class="medal <?php echo esc_attr($medal_class); ?>"><?php echo esc_html($comp->medals); ?></span></td>
                                         <td><?php echo esc_html($comp->points); ?> pts</td>
                                     </tr>
-                                    <?php
+                            <?php
                                 }
                             }
                             ?>
@@ -292,7 +292,7 @@ class Judoka_Performance_Shortcode
                     </table>
                 </div>
             </div>
-            
+
             <div id="contests" class="tab-content">
                 <h2>Competition history</h2>
                 <div class="competitions-filters">
@@ -309,7 +309,7 @@ class Judoka_Performance_Shortcode
                         }
                         ?>
                     </select>
-                    
+
                     <select id="medal-filter">
                         <option value="all">All medals</option>
                         <option value="Gold">Gold</option>
@@ -318,7 +318,7 @@ class Judoka_Performance_Shortcode
                         <option value="none">No medal</option>
                     </select>
                 </div>
-                
+
                 <table class="competitions-table full-width">
                     <thead>
                         <tr>
@@ -337,7 +337,7 @@ class Judoka_Performance_Shortcode
                             foreach ($competitions as $comp) {
                                 $medal_class = strtolower($comp->medals);
                                 $year = date('Y', strtotime($comp->date_competition));
-                                ?>
+                        ?>
                                 <tr data-year="<?php echo esc_attr($year); ?>" data-medal="<?php echo esc_attr($comp->medals); ?>">
                                     <td><?php echo esc_html(date('d/m/Y', strtotime($comp->date_competition))); ?></td>
                                     <td><?php echo esc_html($comp->competition_name); ?></td>
@@ -345,14 +345,14 @@ class Judoka_Performance_Shortcode
                                     <td><span class="medal <?php echo esc_attr($medal_class); ?>"><?php echo esc_html($comp->medals); ?></span></td>
                                     <td><?php echo esc_html($comp->points); ?> pts</td>
                                 </tr>
-                                <?php
+                        <?php
                             }
                         }
                         ?>
                     </tbody>
                 </table>
             </div>
-            
+
             <div id="photos" class="tab-content">
                 <h2>Photos gallery</h2>
                 <div class="photo-gallery">
@@ -368,20 +368,19 @@ class Judoka_Performance_Shortcode
                     ?>
                 </div>
             </div>
-            
+
             <div id="videos" class="tab-content">
                 <h2>Vidéos</h2>
                 <p>No videos available.</p>
             </div>
-            
+
             <div id="results" class="tab-content">
                 <h2>Detailed results</h2>
                 <p>Detailed result data coming soon.</p>
             </div>
         </div>
-        <?php
+<?php
         return ob_get_clean();
-
     }
 
     public function ajax_get_judoka_details()
@@ -389,7 +388,7 @@ class Judoka_Performance_Shortcode
         check_ajax_referer('judoka_performance_nonce', 'nonce');
 
         $judoka_id = isset($_POST['judoka_id']) ? intval($_POST['judoka_id']) : 0;
-        
+
         if ($judoka_id) {
             $html = $this->render_judoka_details($judoka_id);
             wp_send_json_success(['html' => $html]);

--- a/includes/shortcodes/class-judoka-ranking-shortcode.php
+++ b/includes/shortcodes/class-judoka-ranking-shortcode.php
@@ -55,7 +55,7 @@ class Judoka_Ranking_Shortcode
         ), $atts);
 
         ob_start();
-        ?>
+?>
         <div class="judoka-ranking-container">
             <div class="ranking-sidebar">
                 <?php $this->render_sidebar_filters(); ?>
@@ -70,13 +70,13 @@ class Judoka_Ranking_Shortcode
                 </div>
             </div>
         </div>
-        <?php
+    <?php
         return ob_get_clean();
     }
 
     private function render_sidebar_filters()
     {
-        ?>
+    ?>
         <div class="weight-gender-filters">
             <div class="gender-section">
                 <h3>Gender</h3>
@@ -86,7 +86,7 @@ class Judoka_Ranking_Shortcode
                     <button class="gender-btn" data-gender="F">F</button>
                 </div>
             </div>
-            
+
             <div class="weight-section">
                 <h3>Weight Categories</h3>
                 <div class="weight-buttons">
@@ -95,11 +95,11 @@ class Judoka_Ranking_Shortcode
                         'M' => ['-60', '-66', '-73', '-81', '-90', '-100', '+100'],
                         'F' => ['-48', '-52', '-57', '-63', '-70', '-78', '+78']
                     ];
-                    
+
                     foreach ($weights as $gender => $categories) {
                         echo '<div class="weight-group" data-gender="' . esc_attr($gender) . '">';
                         foreach ($categories as $weight) {
-                            echo '<button class="weight-btn" data-weight="' . esc_attr($weight) . '">' 
+                            echo '<button class="weight-btn" data-weight="' . esc_attr($weight) . '">'
                                 . esc_html($weight) . '</button>';
                         }
                         echo '</div>';
@@ -108,12 +108,12 @@ class Judoka_Ranking_Shortcode
                 </div>
             </div>
         </div>
-        <?php
+    <?php
     }
 
     private function render_top_filters($atts)
     {
-        ?>
+    ?>
         <div class="ranking-filters">
             <select id="category-filter">
                 <option value="all" <?php selected($atts['category'], 'all'); ?>>All Categories</option>
@@ -138,12 +138,12 @@ class Judoka_Ranking_Shortcode
 
             <input type="text" id="search-name" placeholder="Search by name">
         </div>
-        <?php
+    <?php
     }
 
     private function render_table_header()
     {
-        ?>
+    ?>
         <div class="ranking-header">
             <div class="col-place">Place</div>
             <div class="col-change">Ch.</div>
@@ -152,7 +152,7 @@ class Judoka_Ranking_Shortcode
             <div class="col-points">Points</div>
             <div class="col-details expanded-only">Details</div>
         </div>
-        <?php
+    <?php
     }
 
     private function render_table_body($atts)
@@ -176,25 +176,25 @@ class Judoka_Ranking_Shortcode
         $photo_url = !empty($judoka->photo_profile) ? $judoka->photo_profile : $this->default_picture;
         $previous_rank = $this->get_previous_rank($judoka->id);
         $rank_change = $previous_rank ? $previous_rank - $rank : 0;
-        ?>
-        <div class="ranking-row" 
-             data-category="<?php echo esc_attr($judoka->category); ?>"
-             data-gender="<?php echo esc_attr($judoka->gender); ?>"
-             data-weight="<?php echo esc_attr($judoka->weight); ?>"
-             data-club="<?php echo esc_attr($judoka->club); ?>">
-            
+    ?>
+        <div class="ranking-row"
+            data-category="<?php echo esc_attr($judoka->category); ?>"
+            data-gender="<?php echo esc_attr($judoka->gender); ?>"
+            data-weight="<?php echo esc_attr($judoka->weight); ?>"
+            data-club="<?php echo esc_attr($judoka->club); ?>">
+
             <div class="col-place">#<?php echo esc_html($rank); ?></div>
             <div class="col-change"><?php $this->render_rank_change($rank_change); ?></div>
             <div class="col-competitor">
-                <img src="<?php echo esc_url($photo_url); ?>" 
-                     alt="<?php echo esc_attr($judoka->full_name); ?>" 
-                     class="judoka-photo">
+                <img src="<?php echo esc_url($photo_url); ?>"
+                    alt="<?php echo esc_attr($judoka->full_name); ?>"
+                    class="judoka-photo">
                 <span class="judoka-name"><?php echo esc_html($judoka->full_name); ?></span>
             </div>
             <div class="col-nation">
-                <img src="<?php echo esc_url($this->default_flag); ?>" 
-                     alt="Cameroon flag" 
-                     class="nation-flag">
+                <img src="<?php echo esc_url($this->default_flag); ?>"
+                    alt="Cameroon flag"
+                    class="nation-flag">
                 <span><?php echo esc_html($judoka->club); ?></span>
             </div>
             <div class="col-points">
@@ -209,7 +209,7 @@ class Judoka_Ranking_Shortcode
                     if (!empty($competitions)) {
                         echo '<p>Recent competitions:</p><ul>';
                         foreach (array_slice($competitions, 0, 3) as $comp) {
-                            echo '<li>' . esc_html($comp->competition_name) . ' - ' 
+                            echo '<li>' . esc_html($comp->competition_name) . ' - '
                                 . esc_html($comp->points) . ' points</li>';
                         }
                         echo '</ul>';
@@ -218,7 +218,7 @@ class Judoka_Ranking_Shortcode
                 </div>
             </div>
         </div>
-        <?php
+<?php
     }
 
     private function render_rank_change($change)
@@ -325,8 +325,7 @@ class Judoka_Ranking_Shortcode
             $current_date
         ));
 
-        if ($existing_snapshot > 0)
-        {
+        if ($existing_snapshot > 0) {
             return;
         }
 
@@ -363,7 +362,7 @@ class Judoka_Ranking_Shortcode
         );
 
         $judokas = $this->get_ranked_judokas($filters);
-        
+
         ob_start();
         foreach ($judokas as $rank => $judoka) {
             $this->render_judoka_row($judoka, $rank + 1);


### PR DESCRIPTION
- Convert weight input field to select dropdown in judoka-form.php
- Add male/female weight categories with appropriate prefixes (-60, -66, etc.)
- Group weight options by gender (Male/Female)
- Fix weight display in performance shortcode to prevent duplicate hyphen
- Ensure consistent weight format across the application

These changes improve data consistency by limiting weight values to standard judo weight categories and fix display issues in the performance shortcode.